### PR TITLE
fix IsAlive and use SSH master

### DIFF
--- a/proc.go
+++ b/proc.go
@@ -110,7 +110,7 @@ func NewProc(name string, args ...string) (proc *Proc, err error) {
 
 // IsAlive reports whether the process is still running.
 func (proc Proc) IsAlive() bool {
-	return proc.cmd == nil
+	return proc.cmd != nil
 }
 
 // Signal sends the given signal to proc.

--- a/readme.md
+++ b/readme.md
@@ -451,14 +451,11 @@ could use one of our custom glue scripts:
 
 It's not significantly slower than running plain [SSH][].
 
-If you are using session sharing (`ControlMaster` and friends) in auto
-mode with `ControlPersist`, Judo will wait until the master in the
-background exits. If it's not cool, you're advised to disable it.
+Judo automatically starts a master SSH session through which all other
+sessions are multiplexed to avoid the overhead of establishing multiple
+SSH connections.
 
-You could also keep a master SSH connection open somewhere else in the
-background. Since Judo invokes [`ssh(1)`][man-ssh] and
-[`scp(1)`][man-ssh] a couple of times per each session, this may speed
-things up significantly.
+Patches/ideas to further speed up Judo are welcome.
 
 ## A book?
 

--- a/transport.go
+++ b/transport.go
@@ -8,10 +8,15 @@ import (
 	"time"
 )
 
+const (
+	sshControlPath    = "~/.ssh/judo-control-%C"
+	sshControlPathOpt = "-o ControlPath " + sshControlPath
+)
+
 func (host *Host) pushFiles(job *Job,
 	fnameLocal string, fnameRemote string) (err error) {
 	var remote = fmt.Sprintf("[%s]:%s", host.Name, fnameRemote)
-	proc, err := NewProc("scp", "-r", fnameLocal, remote)
+	proc, err := NewProc("scp", sshControlPathOpt, "-r", fnameLocal, remote)
 	if err != nil {
 		return
 	}
@@ -66,7 +71,10 @@ func shargs(ss []string) string {
 }
 
 func (host *Host) startSSH(job *Job, command string) (proc *Proc, err error) {
-	sshArgs := []string{host.Name}
+	sshArgs := []string{
+		sshControlPathOpt,
+		host.Name,
+	}
 	if host.workdir != "" {
 		sshArgs = append(sshArgs, []string{
 			"cd", host.workdir, "&&",
@@ -146,7 +154,7 @@ func (host *Host) StartMaster() (err error) {
 	if host.master != nil {
 		panic("there already is a master")
 	}
-	proc, err := NewProc("ssh", "-MN", host.Name)
+	proc, err := NewProc("ssh", sshControlPathOpt, "-MN", host.Name)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
These commits fixes the IsAlive issue in #2 and adds the required args for SSH/SCP to use the master created by Host.StartMaste()r.

Performance improvement for high-latency hosts appears to be considerable:

```
real    0m7.851s
user    0m6.095s
sys     0m0.062s

real    0m23.095s
user    0m17.673s
sys     0m0.079s
```

You can verify that the SSH master is actually being used by adding the v flag to the SSH master invocation:

```
At transport.go:157, replace:
proc, err := NewProc("ssh", sshControlPathOpt, "-MN", host.Name)
with
proc, err := NewProc("ssh", sshControlPathOpt, "-MNv", host.Name)
```

Hope these patches are correct and I'm not overlooking something obvious!