### PR TITLE
explicitly specify ControlMaster no for slave SSH processes

### DIFF
--- a/inventory.go
+++ b/inventory.go
@@ -25,7 +25,7 @@ func NewInventory() *Inventory {
 	return &Inventory{
 		hosts:   []*Host{},
 		s:       NewSeenString(),
-		Timeout: time.Duration(30) * time.Second,
+		Timeout: time.Duration(5) * time.Minute,
 		logger:  log.New(os.Stderr, "inventory: ", 0),
 	}
 }

--- a/transport.go
+++ b/transport.go
@@ -16,7 +16,7 @@ const (
 
 func (host *Host) pushFiles(job *Job,
 	fnameLocal string, fnameRemote string) (err error) {
-	var remote = fmt.Sprintf("[%s]:%s", host.Name, fnameRemote)
+	var remote = fmt.Sprintf("%s:%s", host.Name, fnameRemote)
 	proc, err := NewProc("scp",
 		sshControlPathOpt,
 		sshControlMasterNoOpt,

--- a/transport.go
+++ b/transport.go
@@ -9,14 +9,18 @@ import (
 )
 
 const (
-	sshControlPath    = "~/.ssh/judo-control-%C"
-	sshControlPathOpt = "-o ControlPath " + sshControlPath
+	sshControlPath        = "~/.ssh/judo-control-%C"
+	sshControlPathOpt     = "-o ControlPath " + sshControlPath
+	sshControlMasterNoOpt = "-o ControlMaster no"
 )
 
 func (host *Host) pushFiles(job *Job,
 	fnameLocal string, fnameRemote string) (err error) {
 	var remote = fmt.Sprintf("[%s]:%s", host.Name, fnameRemote)
-	proc, err := NewProc("scp", sshControlPathOpt, "-r", fnameLocal, remote)
+	proc, err := NewProc("scp",
+		sshControlPathOpt,
+		sshControlMasterNoOpt,
+		"-r", fnameLocal, remote)
 	if err != nil {
 		return
 	}
@@ -73,6 +77,7 @@ func shargs(ss []string) string {
 func (host *Host) startSSH(job *Job, command string) (proc *Proc, err error) {
 	sshArgs := []string{
 		sshControlPathOpt,
+		sshControlMasterNoOpt,
 		host.Name,
 	}
 	if host.workdir != "" {


### PR DESCRIPTION
This should keep Judo away from your ssh config's ControlMaster. Could you test with your config?

I was working under the assumption that your config had the following line in it:
```
ControlMaster auto
```

By the way, could you let me know why the destination hostname for Judo's scp command is enclosed in square brackets?

```
transport.go:18
var remote = fmt.Sprintf("[%s]:%s", host.Name, fnameRemote)
```