### PR TITLE
Fix for custom SSH_CONFIG on executing scripts.

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -180,7 +180,10 @@ func (host *Host) StartMaster() (err error) {
 	if host.master != nil {
 		panic("there already is a master")
 	}
-	proc, err := NewProc("ssh", sshBatchOpt, sshControlPathOpt, "-MN", host.Name)
+        sshArgs := []string{}
+        sshArgs = append(sshArgs, host.SshArgs...)
+        sshArgs = append(sshArgs, sshBatchOpt, sshControlPathOpt, "-MN", host.Name)
+        proc, err := NewProc("ssh", sshArgs...)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This is needed to correctly connect SSH master process with a custom SSH_CONFIG.