### PR TITLE
Fix some remote command quoting

### DIFF
--- a/host.go
+++ b/host.go
@@ -46,8 +46,8 @@ func (host *Host) SendRemoteAndRun(job *Job) (err error) {
 	defer host.StopMaster()
 
 	// make cozy
-	err = host.SSH(job, "mkdir -p $HOME/.judo")
-	workdir, err := host.SSHRead(job, "TMPDIR=$HOME/.judo mktemp -d")
+	err = host.SSH(job, `mkdir -p "$HOME/.judo"`)
+	workdir, err := host.SSHRead(job, `TMPDIR="$HOME/.judo" mktemp -d`)
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (host *Host) SendRemoteAndRun(job *Job) (err error) {
 
 	cleanup := func() error {
 		host.workdir = ""
-		return host.SSH(job, fmt.Sprintf("rm -r %s", workdir))
+		return host.SSH(job, fmt.Sprintf("rm -r %s", shquote(workdir)))
 	}
 
 	// ensure cleanup
@@ -85,7 +85,7 @@ func (host *Host) SendRemoteAndRun(job *Job) (err error) {
 	// Create remote directory structure
 	if err = host.SSH(
 		job,
-		fmt.Sprintf("mkdir -p %s", remoteScriptDir),
+		fmt.Sprintf("mkdir -p %s", shquote(remoteScriptDir)),
 	); err != nil {
 		return err
 	}

--- a/transport.go
+++ b/transport.go
@@ -104,7 +104,7 @@ func (host *Host) startSSH(job *Job, command string) (proc *Proc, err error) {
 	}
 	sshArgs = append(sshArgs, "env")
 	for key, value := range host.Env {
-		sshArgs = append(sshArgs, fmt.Sprintf("%s=%s", key, value))
+		sshArgs = append(sshArgs, fmt.Sprintf("%s=%s", key, shquote(value)))
 	}
 	sshArgs = append(sshArgs, "sh", "-c", shquote(command))
 	return NewProc("ssh", sshArgs...)


### PR DESCRIPTION
This is mostly to enable pushing environment variable values containing spaces, but should fix some more possible errors.

My use case is a judo script file that creates a user on a host, and can receive the content of a `.ssh/authorized_keys`. That does not work with the current version of judo.